### PR TITLE
[FIX] combine+join; add removeRoute()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,25 @@ console.log(simplified.getPoints())
 ``` js
 const r = require('five-bells-routing')
 
-console.log(__dirname)
-// prints '/opt/workspace/five-bells-routing/.tmp'
-console.log(require.resolve('../test/fixtures/route-usd-xrp-gatehub.json'))
-// prints '/opt/workspace/five-bells-routing/test/fixtures/route-usd-xrp-gatehub.json'
-console.log(require.resolve('../test/fixtures/route-usd-xrp-bitstamp.json'))
-// prints '/opt/workspace/five-bells-routing/test/fixtures/route-usd-xrp-bitstamp.json'
 const route1 = new r.Route(require('../test/fixtures/route-usd-xrp-gatehub.json'))
 const route2 = new r.Route(require('../test/fixtures/route-usd-xrp-bitstamp.json'))
 const route = route1.combine(route2).simplify(3)
 console.log(route.getPoints())
-// prints [[0,0],[8034.771375,1068903],[14654.350698,1883992]]
+// prints [[0,0],[4584.292323,612465],[14654.350698,1883992]]
+```
+
+``` js
+const r = require('five-bells-routing')
+const route1 = new r.Route([ [0, 0], [50, 60] ])
+const route2 = new r.Route([ [0, 0], [100, 100] ])
+const route = route1.combine(route2)
+
+console.log(route.amountAt(50))
+// prints 60
+console.log(route.amountAt(60))
+// prints 60
+console.log(route.amountAt(70))
+// prints 70
 ```
 
 ### Join two routes
@@ -51,7 +59,7 @@ const route1 = new r.Route(require('../test/fixtures/route-usd-xrp-gatehub.json'
 const route2 = new r.Route(require('../test/fixtures/route-xrp-jpy-tokyojpy.json'))
 const route = route1.join(route2).simplify(3)
 console.log(route.getPoints())
-// prints [[0,0],[3145.958076,352662.5329103215],[10726.26,757237.079362416]]
+// prints [[0,0],[2736.957536,309417.18604060914],[Infinity,3942622.7]]
 ```
 
 ### Create a Routing Table
@@ -72,7 +80,15 @@ table.addRoute('jpy', 'gatehub', route.usdXrpGatehub.join(route.xrpJpyTokyoJpy))
 table.addRoute('jpy', 'bitstamp', route.usdXrpBitstamp.join(route.xrpJpyTokyoJpy))
 
 console.log(table.findBestHopForSourceAmount('jpy', 210))
-// prints { bestHop: 'gatehub', bestValue: 24158.461997982795 }
+// prints { bestHop: 'gatehub', bestValue: 24205.50993427375 }
 console.log(table.findBestHopForDestinationAmount('jpy', 24158))
-// prints { bestHop: 'gatehub', bestCost: 209.9959702869346 }
+// prints { bestHop: 'gatehub', bestCost: 209.586929865 }
+```
+
+``` js
+const r = require('five-bells-routing')
+const route1 = new r.Route([ [0, 0], [200, 100] ])
+const route2 = new r.Route([ [0, 0], [50, 60] ])
+route1.join(route2).amountAt(100)
+// prints 60
 ```

--- a/src/lib/routing-table.js
+++ b/src/lib/routing-table.js
@@ -14,6 +14,13 @@ class RoutingTable {
     routes.set(nextHop, metric)
   }
 
+  removeRoute (destination, nextHop) {
+    const routes = this.destinations.get(destination)
+    if (!routes) return
+    routes.delete(nextHop)
+    if (routes.size === 0) this.destinations.delete(destination)
+  }
+
   findBestHopForSourceAmount (destination, sourceAmount) {
     const routes = this.destinations.get(destination)
     if (!routes) return undefined


### PR DESCRIPTION
- Fix `combine` at intersections.
- Use correct `x` (not `g(x)`) values when mapping the route in `join`.
- Add tests that showcase the previously broken behavior of combine and join.
- Add `RoutingTable#removeRoute`.
